### PR TITLE
Corrected "compatible core version"

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
   "library": "false",
   "manifestPlusVersion": "1.0.0",
   "minimumCoreVersion": "0.8.6",
-  "compatibleCoreVersion": "9.224",
+  "compatibleCoreVersion": "9",
   "socket": true,
   "authors": [
     {


### PR DESCRIPTION
In foundry V9 the build number does not have to be specified. After this change the "compatibility risk" warning disappears in Foundry V9